### PR TITLE
Add back camera dimensions for iPhone 6 and 6+

### DIFF
--- a/UIDeviceUtil.m
+++ b/UIDeviceUtil.m
@@ -311,6 +311,8 @@
     case IPHONE_5_CDMA_GSM:
     case IPHONE_5C:
     case IPHONE_5C_CDMA_GSM:
+    case IPHONE_6:
+    case IPHONE_6_PLUS:
       return CGSizeMake(3264, 2448);
       break;
 


### PR DESCRIPTION
I have access to both an iPhone 6 and a 6+.  I took pictures with each and verified the camera resolutions are 2448x3264.